### PR TITLE
Deploy Gnosis Chain subgraph to Goldsky

### DIFF
--- a/config/xdai.json
+++ b/config/xdai.json
@@ -1,0 +1,8 @@
+{
+    "network": "xdai",
+    "contracts": {
+      "umbra": {
+        "startBlock": 28237949
+      }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "deploy:optimism": "yarn build && yarn codegen && yarn prepare:optimism && graph deploy --node https://api.thegraph.com/deploy/ ScopeLift/UmbraOptimism",
     "deploy:polygon": "yarn build && yarn codegen && yarn prepare:polygon && graph deploy --node https://api.thegraph.com/deploy/ ScopeLift/UmbraPolygon",
     "deploy:rinkeby": "yarn build && yarn codegen && yarn prepare:rinkeby && graph deploy --node https://api.thegraph.com/deploy/ ScopeLift/UmbraRinkeby",
-    "deploy:sepolia": "yarn build && yarn codegen && yarn prepare:sepolia && goldsky subgraph deploy 'umbra-sepolia/v1.0.0",
+    "deploy:sepolia": "yarn build && yarn codegen && yarn prepare:sepolia && goldsky subgraph deploy umbra-sepolia/v1.0.0",
+    "deploy:xdai": "yarn build && yarn codegen && yarn prepare:xdai && goldsky subgraph deploy umbra-xdai/v1.0.0",
     "prepare:arbitrumOne": "mustache config/arbitrum.json subgraph.template.yaml > subgraph.yaml",
     "prepare:goerli": "mustache config/goerli.json subgraph.template.yaml > subgraph.yaml",
     "prepare:mainnet": "mustache config/mainnet.json subgraph.template.yaml > subgraph.yaml",
@@ -21,6 +22,7 @@
     "prepare:polygon": "mustache config/polygon.json subgraph.template.yaml > subgraph.yaml",
     "prepare:rinkeby": "mustache config/rinkeby.json subgraph.template.yaml > subgraph.yaml",
     "prepare:sepolia": "mustache config/sepolia.json subgraph.template.yaml > subgraph.yaml",
+    "prepare:xdai": "mustache config/xdai.json subgraph.template.yaml > subgraph.yaml",
     "prettier": "prettier --write .",
     "remove-local": "graph remove --node http://localhost:8020/ ScopeLift/umbra"
   },


### PR DESCRIPTION
Note: Goldsky's string identifier for Gnosis Chain is `xdai` so we use/follow that convention here.