### PR TITLE
Added support for Base chain via subgraph on Alchemy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+BASE_DEPLOY_KEY=<access-token>

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 3. Authenticate with `yarn graph auth https://api.thegraph.com/deploy/ <access-token>`
 4. Deploy with `yarn deploy:<network>`
 
-Note: For the Base network subgraph (which is deployed to Alchemy), step 3 above should be skipped, and it will be necessary to create a .env file with the following content:
+Note: For the Base network subgraph (which is deployed to Alchemy), step 3 above should be skipped, and it will be necessary to create a .env file with the following content, to authenticate access to that subgraph:
 
 ```
 BASE_DEPLOY_KEY=<access-token>
 ```
 
-in order to authenticate the Alchemy deploy of the Base network subgraph.
+You can copy the .env.example file and replace the placeholder with the actual access token.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,11 @@
 2. Update contract details in the `config` folder
 3. Authenticate with `yarn graph auth https://api.thegraph.com/deploy/ <access-token>`
 4. Deploy with `yarn deploy:<network>`
+
+Note: For the Base network subgraph (which is deployed to Alchemy), step 3 above should be skipped, and it will be necessary to create a .env file with the following content:
+
+```
+BASE_DEPLOY_KEY=<access-token>
+```
+
+in order to authenticate the Alchemy deploy of the Base network subgraph.

--- a/config/base.json
+++ b/config/base.json
@@ -1,0 +1,8 @@
+{
+  "network": "base",
+  "contracts": {
+    "umbra": {
+      "startBlock": 10761374
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "create-local": "graph create --node http://localhost:8020/ ScopeLift/umbra",
     "deploy:all": "yarn deploy:polygon && yarn deploy:mainnet && yarn deploy:arbitrumOne && yarn deploy:optimism && yarn deploy:sepolia && yarn deploy:xdai",
     "deploy:arbitrumOne": "yarn build && yarn codegen && yarn prepare:arbitrumOne && goldsky subgraph deploy umbra-arbitrum-one/v1.1.0",
+    "deploy:base": "yarn build && yarn codegen && yarn prepare:base && node script/deploy_base.js",
     "deploy:local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 ScopeLift/umbra",
     "deploy:mainnet": "yarn build && yarn codegen && yarn prepare:arbitrumOne && goldsky subgraph deploy umbra-mainnet/v1.1.0",
     "deploy:optimism": "yarn build && yarn codegen && yarn prepare:arbitrumOne && goldsky subgraph deploy umbra-optimism/v1.1.0",
@@ -14,6 +15,7 @@
     "deploy:sepolia": "yarn build && yarn codegen && yarn prepare:sepolia && goldsky subgraph deploy umbra-sepolia/v1.1.0",
     "deploy:xdai": "yarn build && yarn codegen && yarn prepare:xdai && goldsky subgraph deploy umbra-xdai/v1.1.0",
     "prepare:arbitrumOne": "mustache config/arbitrum.json subgraph.template.yaml > subgraph.yaml",
+    "prepare:base": "mustache config/base.json subgraph.template.yaml > subgraph.yaml",
     "prepare:mainnet": "mustache config/mainnet.json subgraph.template.yaml > subgraph.yaml",
     "prepare:optimism": "mustache config/optimism.json subgraph.template.yaml > subgraph.yaml",
     "prepare:polygon": "mustache config/polygon.json subgraph.template.yaml > subgraph.yaml",
@@ -25,7 +27,9 @@
   "dependencies": {
     "@goldskycom/cli": "^1.8.0",
     "@graphprotocol/graph-cli": "0.50.0",
-    "@graphprotocol/graph-ts": "0.30.0"
+    "@graphprotocol/graph-ts": "0.30.0",
+    "dotenv": "^16.4.5",
+    "shelljs": "^0.8.5"
   },
   "devDependencies": {
     "mustache": "^4.2.0",

--- a/script/deploy_base.js
+++ b/script/deploy_base.js
@@ -1,0 +1,7 @@
+require('dotenv').config();
+const shell = require('shelljs');
+
+const deployKey = process.env.BASE_DEPLOY_KEY;
+const command = `graph deploy umbra-base --version-label v1.1.0 --node https://subgraphs.alchemy.com/api/subgraphs/deploy --deploy-key ${deployKey} --ipfs https://ipfs.satsuma.xyz`;
+
+shell.exec(command);


### PR DESCRIPTION
For Base chain, added subgraph on Alchemy.

Because Alchemy requires a key for deployment, and because the commands to deploy are contained in the 'package.json' file (which doesn't allow env var substitution) it was necessary to invoke a deploy script just for Base so that the script could make use of a .env file to acquire the deployment key to avoid committing the key to the repo.